### PR TITLE
Change function invocation order relevant to encoding. Add new class.

### DIFF
--- a/docs/rl-env/encoding-plan.rst
+++ b/docs/rl-env/encoding-plan.rst
@@ -12,7 +12,7 @@ Encoding Plan
 
     .. automethod:: __init__
 
-``EncodingPlanFast`` is a subclass of ``EncodingPlan`` whose ``encode`` would always return None.
+``LazyEncodingPlan`` is a subclass of ``EncodingPlan`` whose ``encode`` would always return None.
 
-.. autoclass:: dgisim.encoding.encoding_plan.EncodingPlanFast
+.. autoclass:: dgisim.encoding.encoding_plan.LazyEncodingPlan
     .. automethod:: encode

--- a/docs/rl-env/encoding-plan.rst
+++ b/docs/rl-env/encoding-plan.rst
@@ -12,7 +12,7 @@ Encoding Plan
 
     .. automethod:: __init__
 
-``LazyEncodingPlan`` is a subclass of ``EncodingPlan`` whose ``encode`` would always return None.
+``LazyEncodingPlan`` is a subclass of ``EncodingPlan`` whose ``encode`` would always return an empty list.
 
 .. autoclass:: dgisim.encoding.encoding_plan.LazyEncodingPlan
     .. automethod:: encode

--- a/docs/rl-env/encoding-plan.rst
+++ b/docs/rl-env/encoding-plan.rst
@@ -11,3 +11,8 @@ Encoding Plan
     :members:
 
     .. automethod:: __init__
+
+``EncodingPlanFast`` is a subclass of ``EncodingPlan`` whose ``encode`` would always return None.
+
+.. autoclass:: dgisim.encoding.encoding_plan.EncodingPlanFast
+    .. automethod:: encode

--- a/src/dgisim/encoding/encoding_plan.py
+++ b/src/dgisim/encoding/encoding_plan.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "EncodingPlan",
-    "EncodingPlanFast",
+    "LazyEncodingPlan",
     "encoding_plan",
     "GameItem",
     "GameItemType",
@@ -235,7 +235,7 @@ class EncodingPlan:
             and mode.all_chars().issubset(self._char_mapping.keys())
         )
 
-    def encode(self, game_state: "GameState", perspective:Pid) -> list[int]:
+    def encode(self, game_state: "GameState", perspective: Pid) -> list[int]:
         return game_state.encoding(self, perspective)
 
     @property
@@ -262,7 +262,12 @@ class EncodingPlan:
             self._flip_cache = new_self
         return self._flip_cache
 
-class EncodingPlanFast(EncodingPlan):
+class LazyEncodingPlan(EncodingPlan):
+    """
+    A lazy version of EncodingPlan that does not encode anything, returning None.
+
+    It can accelerate env.step() if you don't need the encoding instantly.
+    """
     def encode(self, game_state: "GameState", perspective:Pid):
         """
         :returns: None.
@@ -287,7 +292,7 @@ if __name__ == "__main__":
 
     indent = 0
     game_state = GameState.from_default()
-    encoding = game_state.encoding(encoding_plan)
+    encoding = encoding_plan.encode(game_state, Pid.P1)
     print(f"game_state size = {len(encoding)}")
 
     player = game_state.player1

--- a/src/dgisim/encoding/encoding_plan.py
+++ b/src/dgisim/encoding/encoding_plan.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "EncodingPlan",
+    "EncodingPlanFast",
     "encoding_plan",
     "GameItem",
     "GameItemType",
@@ -234,8 +235,8 @@ class EncodingPlan:
             and mode.all_chars().issubset(self._char_mapping.keys())
         )
 
-    def encode(self, game_state: "GameState") -> list[int]:
-        return game_state.encoding(self)
+    def encode(self, game_state: "GameState", perspective:Pid) -> list[int]:
+        return game_state.encoding(self, perspective)
 
     @property
     def game_encoding_size(self) -> int:
@@ -260,6 +261,13 @@ class EncodingPlan:
             new_self._perspective = pid
             self._flip_cache = new_self
         return self._flip_cache
+
+class EncodingPlanFast(EncodingPlan):
+    def encode(self, game_state: "GameState", perspective:Pid):
+        """
+        :returns: None.
+        """
+        return None
 
 encoding_plan = EncodingPlan(
     enum_mapping=ENUM_MAPPING,

--- a/src/dgisim/encoding/encoding_plan.py
+++ b/src/dgisim/encoding/encoding_plan.py
@@ -268,7 +268,7 @@ class LazyEncodingPlan(EncodingPlan):
 
     It can accelerate env.step() if you don't need the encoding instantly.
     """
-    def encode(self, game_state: "GameState", perspective:Pid):
+    def encode(self, game_state: "GameState", perspective: Pid) -> list[int]:
         """
         :returns: [].
         """

--- a/src/dgisim/encoding/encoding_plan.py
+++ b/src/dgisim/encoding/encoding_plan.py
@@ -270,7 +270,7 @@ class LazyEncodingPlan(EncodingPlan):
     """
     def encode(self, game_state: "GameState", perspective:Pid):
         """
-        :returns: None.
+        :returns: [].
         """
         return []
 

--- a/src/dgisim/encoding/encoding_plan.py
+++ b/src/dgisim/encoding/encoding_plan.py
@@ -272,7 +272,7 @@ class LazyEncodingPlan(EncodingPlan):
         """
         :returns: None.
         """
-        return None
+        return []
 
 encoding_plan = EncodingPlan(
     enum_mapping=ENUM_MAPPING,

--- a/src/dgisim/env/linear_env.py
+++ b/src/dgisim/env/linear_env.py
@@ -150,7 +150,7 @@ class LinearEnv:
                 )
                 return (
                     perspective_state,
-                    perspective_state.encoding(self._encoding_plan, Pid(turn)),
+                    self._encoding_plan.encode(perspective_state, Pid(turn)),
                     (
                         self._invalid_action_penalty
                         if turn == 1
@@ -170,7 +170,7 @@ class LinearEnv:
             perspective_state = self._curr_state.prespective_view(Pid(turn))
             return (
                 perspective_state,
-                perspective_state.encoding(self._encoding_plan, Pid(turn)),
+                self._encoding_plan.encode(perspective_state, Pid(turn)),
                 (
                     self._invalid_action_penalty
                     if turn == 1

--- a/src/dgisim/env/linear_env.py
+++ b/src/dgisim/env/linear_env.py
@@ -110,7 +110,7 @@ class LinearEnv:
                 perspective = Pid.P2 if self._fix_perspective else Pid.P1
         return (
             perspective_state,
-            perspective_state.encoding(self._encoding_plan, perspective),
+            self._encoding_plan.encode(perspective_state, perspective),
             0,
             turn,
             self._curr_state.game_end(),
@@ -197,7 +197,7 @@ class LinearEnv:
 
         return (
             perspective_state,
-            perspective_state.encoding(self._encoding_plan, Pid.P2 if turn == 2 else Pid.P1),
+            self._encoding_plan.encode(perspective_state, Pid.P2 if turn == 2 else Pid.P1),
             self._reward_method(self._curr_state),
             turn,
             self._curr_state.game_end(),


### PR DESCRIPTION
It's about #38 

1. Now LinearEnv would get encoding of GameState by self._encoding_plan.encode(...). Which allows more flexible usage.
2. Add a new class EncodingPlanFast. Its `encode` method would always return None, for faster execution.

It seems encodingplan is not only responsible for encoding game state(I saw PlayAction call it), I implemented a subclass rather than creating a base class. It's consistent with current API.